### PR TITLE
fix(csv): 单元格含回车符(\r)时也需加引号转义

### DIFF
--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -2,7 +2,7 @@
 
 const escapeCell = (v: any): string => {
   const s = v === null || v === undefined ? '' : typeof v === 'object' ? JSON.stringify(v) : String(v)
-  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
 }
 
 /** 将列名与行数据序列化为 CSV 文本 */


### PR DESCRIPTION
escapeCell 仅对 " , \n 加引号，遗漏了 \r。含裸 \r 的单元格写入
CSV 后会被表格软件当作行终止符，导致数据错位。按 RFC 4180 补全。